### PR TITLE
improvements and cleanup of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,13 @@
 - User with extra steps
 - Having fun with what code can do.
 
-#### Look what they made me do :joy: >@>@>@>@>
+#### Look what they made me do :joy:
 
-https://linktr.ee/Xeldrago
+>@>@>@>@> https://linktr.ee/Xeldrago
+
 <span style="color:blue">And i love blue so, im having some blue stuff in this content block</span>
+
+## Code was fun
 
 <p align="center">
   <a href="/anuraghazra/github-readme-stats">
@@ -23,7 +26,6 @@ https://linktr.ee/Xeldrago
   </a>
 </p>
 
-<h1>Code was fun</h1>
 
 <p align="center">
   <a href="/anuraghazra/github-readme-stats">

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 # XELDRAGO
 
-<img src="logo.jpg" alt="logo" width="100">
+<img src="logo.jpg" alt="Xeldrago logo" width="100">
 
 ### Hey people...!!
 
 - Just an ordinary guy
 - User with extra steps
-- Having fun with what code can do.
+- Having fun with what code can do
 
 #### Look what they made me do :joy:
 
 \>@>@>@>@> https://linktr.ee/Xeldrago
 
-And i love blue <!--so, im having some blue stuff in this content block-->
+And I love blue. <!--so, I have some blue stuff in this content block-->
 
 ## Code was fun
 
 <p align="center">
   <a href="https://github.com/anuraghazra/github-readme-stats">
   <!--link to proj page to support author and share-->
-    <img alt="xeldrago's GitHub stats"
+    <img alt="Xeldrago's GitHub stats"
 	src="https://github-readme-stats.vercel.app/api?username=xeldrago&theme=algolia&show_icons=true">
   </a>
 </p>
@@ -27,13 +27,13 @@ And i love blue <!--so, im having some blue stuff in this content block-->
 <p align="center">
   <a href="https://github.com/anuraghazra/github-readme-stats">
   <!--link to proj page to support author and share-->
-    <img alt="xeldrago's top langs"
+    <img alt="Xeldrago's top langs"
 	src="https://github-readme-stats.vercel.app/api/top-langs?username=xeldrago&layout=compact">
   </a>
 </p>
 
-## love to see how the future turns out !!
+## Love to see how the future turns out !!
 
 <p align="center">
-  <img src="codz.svg" alt="its super awesome">
+  <img src="codz.svg" alt="It's super awesome">
 </p>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # XELDRAGO
 
-<img src="logo.jpg" alt="Xeldrago logo" width="100">
+<img src="logo.jpg" width="100"
+    alt="Xeldrago logo/blue dragon on white background" >
 
 ### Hey people...!!
 
@@ -35,5 +36,5 @@ And I love blue. <!--so, I have some blue stuff in this content block-->
 ## Love to see how the future turns out !!
 
 <p align="center">
-  <img src="codz.svg" alt="It's super awesome">
+  <img src="codz.svg" alt="Coding is awesome. Having funzz">
 </p>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # XELDRAGO
 
-![logo](logo.jpg)
+<p align="center">
+  <img src="logo.jpg" alt="logo" height="auto" width="100">
+</p>
 
 ### Hey people...!!
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# XELDRAGO 
+# XELDRAGO
 
 <p align="center">
   <img src="logo.jpg" alt="logo" height="auto" width="100">
@@ -10,24 +10,31 @@
 - User with extra steps
 - Having fun with what code can do.
 
-#### Look what they made me do :joy: >@>@>@>@> https://linktr.ee/Xeldrago <span style="color:blue">And i love blue so, im having some blue stuff in this content block</span>
+#### Look what they made me do :joy: >@>@>@>@>
+
+https://linktr.ee/Xeldrago
+<span style="color:blue">And i love blue so, im having some blue stuff in this content block</span>
 
 <p align="center">
-<a href="/anuraghazra/github-readme-stats">
-<!--link to proj page to support author and share-->
-<img alt="xeldrago's GitHub stats"
-    src="https://github-readme-stats.vercel.app/api?username=xeldrago&theme=algolia&show_icons=true">
-</a>
+  <a href="/anuraghazra/github-readme-stats">
+  <!--link to proj page to support author and share-->
+    <img alt="xeldrago's GitHub stats"
+	src="https://github-readme-stats.vercel.app/api?username=xeldrago&theme=algolia&show_icons=true">
+  </a>
+</p>
+
 <h1>Code was fun</h1>
-<a href="/anuraghazra/github-readme-stats">
-<!--link to proj page to support author and share-->
-<img alt="xeldrago's top langs"
-    src="https://github-readme-stats.vercel.app/api/top-langs?username=xeldrago&layout=compact">
-</a>
+
+<p align="center">
+  <a href="/anuraghazra/github-readme-stats">
+  <!--link to proj page to support author and share-->
+    <img alt="xeldrago's top langs"
+	src="https://github-readme-stats.vercel.app/api/top-langs?username=xeldrago&layout=compact">
+  </a>
 </p>
 
 ## love to see how the future turns out !!
 
-<p align="center"
-<img src="codz.svg" alt="its super awesome">
+<p align="center">
+  <img src="codz.svg" alt="its super awesome">
 </p>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # XELDRAGO 
-<img src="logo.jpg" alt="logo" height="auto" width="100">
+
+<p align="center">
+  <img src="logo.jpg" alt="logo" height="auto" width="100">
+</p>
 
 ### Hey people...!!
 
@@ -8,11 +11,15 @@
 - Having fun with what code can do.
 
 #### Look what they made me do :joy: >@>@>@>@> https://linktr.ee/Xeldrago <span style="color:blue">And i love blue so, im having some blue stuff in this content block</span>
+
+<p align="center">
 [![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=xeldrago&theme=algolia&show_icons=true)](https://github.com/anuraghazra/github-readme-stats)
-# Code was fun 
+<h1>Code was fun</h1>
 [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=xeldrago&layout=compact)](https://github.com/anuraghazra/github-readme-stats)
+</p>
 
 ## love to see how the future turns out !!
+
+<p align="center"
 <img src="codz.svg" alt="its super awesome">
-
-
+</p>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # XELDRAGO
 
-<p align="center">
-  <img src="logo.jpg" alt="logo" height="auto" width="100">
-</p>
+<img src="logo.jpg" alt="logo" height="auto" width="100">
 
 ### Hey people...!!
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 
 #### Look what they made me do :joy:
 
->@>@>@>@> https://linktr.ee/Xeldrago
+\>@>@>@>@> https://linktr.ee/Xeldrago
 
 And i love blue <!--so, im having some blue stuff in this content block-->
 
 ## Code was fun
 
 <p align="center">
-  <a href="/anuraghazra/github-readme-stats">
+  <a href="https://github.com/anuraghazra/github-readme-stats">
   <!--link to proj page to support author and share-->
     <img alt="xeldrago's GitHub stats"
 	src="https://github-readme-stats.vercel.app/api?username=xeldrago&theme=algolia&show_icons=true">
@@ -25,7 +25,7 @@ And i love blue <!--so, im having some blue stuff in this content block-->
 </p>
 
 <p align="center">
-  <a href="/anuraghazra/github-readme-stats">
+  <a href="https://github.com/anuraghazra/github-readme-stats">
   <!--link to proj page to support author and share-->
     <img alt="xeldrago's top langs"
 	src="https://github-readme-stats.vercel.app/api/top-langs?username=xeldrago&layout=compact">

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # XELDRAGO
 
-<p align="center">
-  <img src="logo.jpg" alt="logo" height="auto" width="100">
-</p>
+![logo](logo.jpg)
 
 ### Hey people...!!
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,17 @@
 #### Look what they made me do :joy: >@>@>@>@> https://linktr.ee/Xeldrago <span style="color:blue">And i love blue so, im having some blue stuff in this content block</span>
 
 <p align="center">
-[![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=xeldrago&theme=algolia&show_icons=true)](https://github.com/anuraghazra/github-readme-stats)
+<a href="/anuraghazra/github-readme-stats">
+<!--link to proj page to support author and share-->
+<img alt="xeldrago's GitHub stats"
+    src="https://github-readme-stats.vercel.app/api?username=xeldrago&theme=algolia&show_icons=true">
+</a>
 <h1>Code was fun</h1>
-[![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=xeldrago&layout=compact)](https://github.com/anuraghazra/github-readme-stats)
+<a href="/anuraghazra/github-readme-stats">
+<!--link to proj page to support author and share-->
+<img alt="xeldrago's top langs"
+    src="https://github-readme-stats.vercel.app/api/top-langs?username=xeldrago&layout=compact">
+</a>
 </p>
 
 ## love to see how the future turns out !!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # XELDRAGO
 
-<img src="logo.jpg" alt="logo" height="auto" width="100">
+<img src="logo.jpg" alt="logo" width="100">
 
 ### Hey people...!!
 
@@ -12,7 +12,7 @@
 
 >@>@>@>@> https://linktr.ee/Xeldrago
 
-<span style="color:blue">And i love blue so, im having some blue stuff in this content block</span>
+And i love blue <!--so, im having some blue stuff in this content block-->
 
 ## Code was fun
 
@@ -23,7 +23,6 @@
 	src="https://github-readme-stats.vercel.app/api?username=xeldrago&theme=algolia&show_icons=true">
   </a>
 </p>
-
 
 <p align="center">
   <a href="/anuraghazra/github-readme-stats">


### PR DESCRIPTION
### center images
> not supported by markdown. use hack.
> wrap image in `<p>` with attr `align=center`
- 5ab6de991f1df73dfeb2e2eeca1abea136f6d13e patch 1/n: prep to center images - wrap in `<p>`
- 5ab6de991f1df73dfeb2e2eeca1abea136f6d13e patch 2/n: convert md imgs to html

### look pretty
- 509e4d8bad5adaa32786513230a278bae84374b8 chore: code formatting
- ce2c8e15a72dc0c892f8d1f693dac980864e79f6 patch: rearrange a bit
- eff8b4713235dc9b54eda8c71adc262c25811c50 patch: logo looks better on left
> yikes! that was a mistake!
- 493a016db1ce8a6597ef499bc1b5800d48ff4e07 Revert "patch: logo looks better on left"
- 493a016db1ce8a6597ef499bc1b5800d48ff4e07 patch: keep logo on left at author's 100px

### no color in GitHub markdown rendering
> GitHub does not support colour, or any style in Markdown
> alternatives to consider
> - listed all over [this thread on StackOverflow](https://stackoverflow.com/q/11509830/13982210)
- 8723ed470b9ebd5a17f7146d06e7b5988a1906f6 patch: remove extraneous elements

### fix errors from previous steps
- 2aedadfbfb2834830aca3282f5b25893cc91fc2e patch: minor fixes

### other improvements
> alt texts are important and anyone who says otherwise is ableist.
> refer [mdn docs on `<img>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-alt)
- 6867545b3f91a30c3506c5805487e9b137dbad17 patch: regularise capitalisation
- 94faa6ead2a9be16f5b82f74a5f900e545347546 feat: improve alt texts
